### PR TITLE
Fixes log output (#18)

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -43,7 +43,7 @@ const startPromise = Promise.try(() => {
 
   // Attach some logging to start/stop
   server.on('listening', () => {
-    logger.log('info', 'KillrVideo Web Server listening on %j', server.address());
+    logger.log('info', 'KillrVideo Web Server listening on %j', server.address(), {});
   });
   server.on('close', () => {
     logger.log('info', 'KillrVideo Web Server is closed');


### PR DESCRIPTION
WInston logging library uses last argument of a log call as metadata, cutting it off. In order to use it with string interpolation, empty object has to be provided as a last argument. 🤣

https://github.com/winstonjs/winston/issues/617#issuecomment-101715967