### PR TITLE
Support for DSE Contact Points Env Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ babel. After cloning the repo, you'll need to pull images, install all dependenc
 > 
 > # Install dependencies & build code for the server & client parts
 > docker-compose run --no-deps -e NODE_ENV=development web npm install
-> docker-compose run --no-deps -e NODE_ENV=development web npm run install:client'
+> docker-compose run --no-deps -e NODE_ENV=development web npm run install:client
 > docker-compose run --no-deps web npm run build
 >
 > # Run the project

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ This will clean, do a build with webpack and babel, and watch the files for chan
 VS Code for development, the tasks checked into the repo should allow you to start the server
 with debugging using `F5`.
 
+## Environment Variables
+
+To change behaviour of the application you can configure environment variables in docker-compose file. For example, you can configure the application to work with your own cassandra cluster instead of the 'built-in' dockerized one. Add the variable to a docker-compose file like here:
+```
+version: '3'
+services:
+  web:
+    ...
+    environment:
+      KILLRVIDEO_DSE_CONTACT_POINTS: 192.168.15.17
+```
+
+### Available Environment Variables
+```
+Logging Level       KILLRVIDEO_LOGGING_LEVEL          verbose
+YouTube API Key     KILLRVIDEO_YOUTUBE_API_KEY        REPLACE_WITH_YOUR_KEY
+Session Secret      KILLRVIDEO_SESSION_SECRET         THE_INTERNET_IS_FULL_OF_CAT_VIDEOS
+Cassandra Host      KILLRVIDEO_DSE_CONTACT_POINTS     dse
+Replication Factor  KILLRVIDEO_CASSANDRA_REPLICATION  "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+Username            KILLRVIDEO_DSE_USERNAME           Null
+Password            KILLRVIDEO_DSE_PASSWORD           Null
+```
+
 ## Releasing
 
 The app is released as a docker image for consumption by service project implementations. We

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -14,4 +14,4 @@ cassandra:
   dsePassword: KILLRVIDEO_DSE_PASSWORD
 
 services:
-  cassandra: KILLRVIDEO_DSE_CONTACTPOINTS
+  cassandra: KILLRVIDEO_DSE_CONTACT_POINTS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -12,3 +12,6 @@ cassandra:
   replication: KILLRVIDEO_CASSANDRA_REPLICATION
   dseUsername: KILLRVIDEO_DSE_USERNAME
   dsePassword: KILLRVIDEO_DSE_PASSWORD
+
+services:
+  cassandra: KILLRVIDEO_DSE_CONTACTPOINTS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -31,14 +31,14 @@ cassandra:
   dsePassword: null
 
 services:
-  web:                    ['web:3000']
-  cassandra:              ['dse']
-  dse-search:             ['dse:8983']
-  UploadsService:         ['backend:50101']
-  RatingsService:         ['backend:50101']
-  CommentsService:        ['backend:50101']
-  SearchService:          ['backend:50101']
-  StatisticsService:      ['backend:50101']
-  VideoCatalogService:    ['backend:50101']
-  UserManagementService:  ['backend:50101']
-  SuggestedVideoService:  ['backend:50101']
+  web:                    'web:3000'
+  cassandra:              'dse'
+  dse-search:             'dse:8983'
+  UploadsService:         'backend:50101'
+  RatingsService:         'backend:50101'
+  CommentsService:        'backend:50101'
+  SearchService:          'backend:50101'
+  StatisticsService:      'backend:50101'
+  VideoCatalogService:    'backend:50101'
+  UserManagementService:  'backend:50101'
+  SuggestedVideoService:  'backend:50101'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   web:
-    #image: hadesarchitect/killrvideo-web:no-etcd
     build: .
     volumes:
       - .:/opt/killrvideo-web
@@ -14,14 +13,14 @@ services:
       KILLRVIDEO_LOGGING_LEVEL: debug
 
   backend:
-    image: hadesarchitect/killrvideo-nodejs:no-etcd
+    image: killrvideo/killrvideo-java:3.0.0
     depends_on:
       - dse
     environment:
       KILLRVIDEO_LOGGING_LEVEL: debug
 
   dse:
-    image: datastax/dse-server:6.0.0
+    image: datastax/dse-server:6.7.0
     command: [ -s -g ]
     ports:
       - "9042:9042"
@@ -36,25 +35,16 @@ services:
       memlock: -1
 
   dse-config:
-    image: killrvideo/killrvideo-dse-config:2.2.1
+    image: killrvideo/killrvideo-dse-config:3.0.0
     environment:
       KILLRVIDEO_SERVICE_DISCOVERY_DISABLED: 'true'
     depends_on:
       - dse
 
   generator:
-    image: killrvideo/killrvideo-generator:3.0.0-rc4
+    image: killrvideo/killrvideo-generator:3.0.0
     depends_on:
       - dse
       - backend
     environment:
       KILLRVIDEO_LOGGING_LEVEL: debug
-
-#  studio:
-#    image: killrvideo/killrvideo-studio:2.0.0
-#    ports:
-#      - "9091:9091"
-#    depends_on:
-#      - dse
-#    environment:
-#      DS_LICENSE: accept

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       KILLRVIDEO_LOGGING_LEVEL: debug
 
   backend:
-    image: killrvideo/killrvideo-java:3.0.0
+    image: killrvideo/killrvideo-nodejs:3.0.0
     depends_on:
       - dse
     environment:

--- a/src/server/utils/lookup-service.js
+++ b/src/server/utils/lookup-service.js
@@ -27,5 +27,5 @@ export function lookupServiceAsync(serviceName) {
 
   logger.log('verbose', `Found service ${serviceName} at ${registry[serviceName]}`);
 
-  return new Promise (function(resolve, reject){resolve(registry[serviceName])});
+  return new Promise (function(resolve, reject){resolve([registry[serviceName]])});
 };


### PR DESCRIPTION
**Done**
- Added support for DSE Contact Points Env Variable
- Updated versions in docker-compose.yaml
- Little clean up and typos 

**To test**
- Review changes
- clone locally & build as described in README
- run without any changes (KILLRVIDEO_DSE_CONTACT_POINTS falls back to a default dse value), localhost:3000 **SHOULD WORK**
- run with Env Var defined to an invalid value (KILLRVIDEO_DSE_CONTACT_POINTS=lolwut), localhost:3000 **_SHOULD FAIL_** (can't contact)
- run with Env Var defined to an valid value (KILLRVIDEO_DSE_CONTACT_POINTS=dse OR KILLRVIDEO_DSE_CONTACT_POINTS=YOURREALCLUSTER), localhost:3000 **SHOULD WORK**