### PR TITLE
Fixes memoization circular call

### DIFF
--- a/src/server/services/factory.js
+++ b/src/server/services/factory.js
@@ -60,7 +60,7 @@ function ensureMemoized(clientInstance) {
     }
   });
   
-  clientInstance.___hasBeenMemoized = true;
+  clientInstance.__hasBeenMemoized = true;
   return clientInstance;
 }
 


### PR DESCRIPTION
KV/Web fails every few days with `Error while calling service killrvideo.video_catalog.VideoCatalogService RangeError: Maximum call stack size exceeded`. 

This is happening because of always failing comparison here: https://github.com/KillrVideo/killrvideo-web/blob/e01f3d12109fa70c10654f545ac0e61b6226f8c1/src/server/services/factory.js#L48
Typo in the variable assignment (see the changeset) leads to recursive memoization:
https://github.com/KillrVideo/killrvideo-web/blob/7012dbce9e53f451d7f7a698180725e80e13639c/src/server/services/factory.js#L63

This PR is to address the issue and handle circular memoization happening inside, in the darkest deeps.

To test:
- review changeset
- wait for a couple of weeks for the results as this fix will be running on production already and we will see if it works
- Build run and test locally, if your will is strong